### PR TITLE
Tweak Drill page infos and program list margins

### DIFF
--- a/src/Components/DrillPage.js
+++ b/src/Components/DrillPage.js
@@ -58,17 +58,17 @@ export const DrillPage = (props) => {
         </View>
         <View style={styles.infoWrapper}>
           <View style={styles.infoSubWrapper}>
-            <Text style={styles.infoDrill}>{drill.durationInMinutes}</Text>
+            <Text style={styles.info}>{drill.durationInMinutes}</Text>
             <Text style={styles.info}>{I18n.t('drillPage.minutes')}</Text>
           </View>
           <View style={styles.separator} />
           <View style={styles.infoSubWrapper}>
-            <Text style={styles.infoDrill}>{drill.minimalPlayersNumber}+</Text>
+            <Text style={styles.info}>{drill.minimalPlayersNumber}+</Text>
             <Text style={styles.info}>{I18n.t('drillPage.players')}</Text>
           </View>
           <View style={styles.separator} />
           <View style={styles.infoSubWrapper}>
-            <Text style={styles.infoDrill}>{I18n.t(`data.levels.${drill.level}`)}</Text>
+            <Text style={styles.info}>{I18n.t(`data.levels.${drill.level}`)}</Text>
             <Text style={styles.info}>{I18n.t('drillPage.level')}</Text>
           </View>
         </View>
@@ -150,9 +150,14 @@ const styles = StyleSheet.create({
     justifyContent: 'space-evenly',
     alignItems: 'center',
   },
+  infoSubWrapper: {
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: 10,
+    flexBasis: '33%',
+  },
   info: {
     color: theme.COLOR_PRIMARY_LIGHT,
-    paddingHorizontal: 30,
     fontSize: theme.FONT_SIZE_MEDIUM,
   },
   separator: {
@@ -188,15 +193,6 @@ const styles = StyleSheet.create({
     color: theme.COLOR_SECONDARY,
     textAlign: 'center',
     fontSize: theme.FONT_SIZE_MEDIUM,
-  },
-  infoDrill: {
-    color: theme.COLOR_PRIMARY_LIGHT,
-    paddingHorizontal: 30,
-    fontSize: theme.FONT_SIZE_LARGE,
-  },
-  infoSubWrapper: {
-    justifyContent: 'center',
-    alignItems: 'center',
   },
   gradient: {
     flex: 1,

--- a/src/Components/__snapshots__/DrillPage.test.js.snap
+++ b/src/Components/__snapshots__/DrillPage.test.js.snap
@@ -407,7 +407,9 @@ exports[`<DrillPage /> renders correctly 1`] = `
                               style={
                                 Object {
                                   "alignItems": "center",
+                                  "flexBasis": "33%",
                                   "justifyContent": "center",
+                                  "paddingHorizontal": 10,
                                 }
                               }
                             >
@@ -415,8 +417,7 @@ exports[`<DrillPage /> renders correctly 1`] = `
                                 style={
                                   Object {
                                     "color": "#fff",
-                                    "fontSize": 20,
-                                    "paddingHorizontal": 30,
+                                    "fontSize": 16,
                                   }
                                 }
                               >
@@ -427,7 +428,6 @@ exports[`<DrillPage /> renders correctly 1`] = `
                                   Object {
                                     "color": "#fff",
                                     "fontSize": 16,
-                                    "paddingHorizontal": 30,
                                   }
                                 }
                               >
@@ -447,7 +447,9 @@ exports[`<DrillPage /> renders correctly 1`] = `
                               style={
                                 Object {
                                   "alignItems": "center",
+                                  "flexBasis": "33%",
                                   "justifyContent": "center",
+                                  "paddingHorizontal": 10,
                                 }
                               }
                             >
@@ -455,8 +457,7 @@ exports[`<DrillPage /> renders correctly 1`] = `
                                 style={
                                   Object {
                                     "color": "#fff",
-                                    "fontSize": 20,
-                                    "paddingHorizontal": 30,
+                                    "fontSize": 16,
                                   }
                                 }
                               >
@@ -468,7 +469,6 @@ exports[`<DrillPage /> renders correctly 1`] = `
                                   Object {
                                     "color": "#fff",
                                     "fontSize": 16,
-                                    "paddingHorizontal": 30,
                                   }
                                 }
                               >
@@ -488,7 +488,9 @@ exports[`<DrillPage /> renders correctly 1`] = `
                               style={
                                 Object {
                                   "alignItems": "center",
+                                  "flexBasis": "33%",
                                   "justifyContent": "center",
+                                  "paddingHorizontal": 10,
                                 }
                               }
                             >
@@ -496,8 +498,7 @@ exports[`<DrillPage /> renders correctly 1`] = `
                                 style={
                                   Object {
                                     "color": "#fff",
-                                    "fontSize": 20,
-                                    "paddingHorizontal": 30,
+                                    "fontSize": 16,
                                   }
                                 }
                               >
@@ -508,7 +509,6 @@ exports[`<DrillPage /> renders correctly 1`] = `
                                   Object {
                                     "color": "#fff",
                                     "fontSize": 16,
-                                    "paddingHorizontal": 30,
                                   }
                                 }
                               >

--- a/src/Components/__snapshots__/ProgramListPage.test.js.snap
+++ b/src/Components/__snapshots__/ProgramListPage.test.js.snap
@@ -1,1004 +1,1007 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<ProgramListPage /> renders correctly when connected 1`] = `
-<View
+<RCTScrollView
   style={
     Object {
       "height": "100%",
-      "paddingVertical": 10,
     }
   }
 >
-  <RCTScrollView>
-    <View>
-      <View>
+  <View>
+    <View
+      style={
+        Object {
+          "marginBottom": 10,
+        }
+      }
+    >
+      <View
+        style={Object {}}
+      >
         <View
-          style={Object {}}
+          accessible={true}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "opacity": 1,
+            }
+          }
         >
           <View
-            accessible={true}
-            focusable={true}
-            onClick={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             style={
               Object {
-                "opacity": 1,
+                "backgroundColor": "#fff",
+                "elevation": 3,
+                "marginTop": 10,
+                "padding": 10,
+                "shadowOffset": Object {
+                  "height": 1,
+                  "width": 0,
+                },
+                "shadowOpacity": 0.3,
+                "shadowRadius": 3,
               }
             }
           >
             <View
               style={
                 Object {
+                  "alignItems": "flex-start",
                   "backgroundColor": "#fff",
-                  "elevation": 3,
-                  "marginBottom": 10,
-                  "padding": 10,
-                  "shadowOffset": Object {
-                    "height": 1,
-                    "width": 0,
-                  },
-                  "shadowOpacity": 0.3,
-                  "shadowRadius": 3,
+                  "paddingHorizontal": 20,
+                  "paddingVertical": 10,
+                  "width": "100%",
                 }
               }
             >
-              <View
+              <Text
                 style={
                   Object {
-                    "alignItems": "flex-start",
-                    "backgroundColor": "#fff",
-                    "paddingHorizontal": 20,
-                    "paddingVertical": 10,
+                    "color": "#232b2b",
+                    "fontSize": 20,
+                    "fontWeight": "bold",
+                  }
+                }
+              >
+                Beginner
+              </Text>
+              <Text
+                style={
+                  Object {
+                    "color": "#232b2b",
+                    "fontSize": 14,
+                    "textAlign": "right",
                     "width": "100%",
                   }
                 }
               >
-                <Text
-                  style={
-                    Object {
-                      "color": "#232b2b",
-                      "fontSize": 20,
-                      "fontWeight": "bold",
-                    }
+                0/2 trainings
+              </Text>
+              <View
+                style={
+                  Object {
+                    "backgroundColor": "#f1f1f1",
+                    "borderRadius": 2,
+                    "height": 3,
+                    "marginTop": 5,
+                    "width": "100%",
                   }
-                >
-                  Beginner
-                </Text>
-                <Text
-                  style={
-                    Object {
-                      "color": "#232b2b",
-                      "fontSize": 14,
-                      "textAlign": "right",
-                      "width": "100%",
-                    }
-                  }
-                >
-                  0/2 trainings
-                </Text>
+                }
+              >
                 <View
                   style={
-                    Object {
-                      "backgroundColor": "#f1f1f1",
-                      "borderRadius": 2,
-                      "height": 3,
-                      "marginTop": 5,
-                      "width": "100%",
-                    }
+                    Array [
+                      Object {
+                        "bottom": 0,
+                        "left": 0,
+                        "position": "absolute",
+                        "right": 0,
+                        "top": 0,
+                      },
+                      Object {
+                        "backgroundColor": "#2a9e91",
+                        "borderRadius": 5,
+                        "width": "50%",
+                      },
+                      Object {
+                        "width": "0%",
+                      },
+                    ]
                   }
-                >
-                  <View
-                    style={
-                      Array [
-                        Object {
-                          "bottom": 0,
-                          "left": 0,
-                          "position": "absolute",
-                          "right": 0,
-                          "top": 0,
-                        },
-                        Object {
-                          "backgroundColor": "#2a9e91",
-                          "borderRadius": 5,
-                          "width": "50%",
-                        },
-                        Object {
-                          "width": "0%",
-                        },
-                      ]
-                    }
-                  />
-                </View>
+                />
               </View>
             </View>
           </View>
-          <View
-            pointerEvents="none"
-            style={
-              Object {
-                "height": 0,
-                "overflow": "hidden",
-              }
+        </View>
+        <View
+          pointerEvents="none"
+          style={
+            Object {
+              "height": 0,
+              "overflow": "hidden",
             }
+          }
+        >
+          <View
+            forwardedRef={[Function]}
+            onLayout={[Function]}
+            style={Object {}}
           >
-            <View
-              forwardedRef={[Function]}
-              onLayout={[Function]}
-              style={Object {}}
-            >
-              <RCTScrollView
-                contentContainerStyle={
+            <RCTScrollView
+              contentContainerStyle={
+                Object {
+                  "marginBottom": 10,
+                }
+              }
+              data={
+                Array [
                   Object {
-                    "marginBottom": 10,
-                  }
-                }
-                data={
-                  Array [
-                    Object {
-                      "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec scelerisque dignissim felis, at tristique mi efficitur a. Nulla pellentesque odio nunc, ut sodales ex pulvinar at. In hac habitasse platea dictumst. Pellentesque sodales nisl lorem, ac lacinia nisl lacinia eu. Proin lacinia viverra mauris, et pharetra ipsum tempus eget. Ut maximus sapien in hendrerit ultricies. Maecenas vel diam tincidunt, consequat nunc a, mattis eros. Curabitur a eros a nulla malesuada gravida. Donec massa quam, suscipit eget efficitur et, euismod sed nulla. Morbi mattis et magna a aliquam. Fusce pellentesque vel erat eget",
-                      "drills": Array [
-                        Object {
-                          "author": "Author",
-                          "description": "Description of the drill",
-                          "durationInMinutes": 10,
-                          "equipment": "Equipment needs for the drill",
-                          "equipmentLabel": "Full",
-                          "goals": Array [
-                            "Legs",
-                          ],
-                          "id": 2,
-                          "image": "http://www.liberte-fitness.fr/sites/default/files/styles/slider/public/news/tone.jpg?itok=505bme2a",
-                          "intensity": "High",
-                          "level": "Intermediate",
-                          "minimalPlayersNumber": 1,
-                          "seasonTiming": "In-season",
-                          "steps": Array [
-                            Object {
-                              "id": 0,
-                              "illustrationSource": "462695757",
-                              "illustrationType": "vimeo",
-                              "subtitle": "This is a subtitle",
-                              "title": "Warmup",
-                            },
-                            Object {
-                              "id": 1,
-                              "illustrationSource": "462695757",
-                              "illustrationType": "vimeo",
-                              "subtitle": "This is a subtitle",
-                              "title": "Do the drill",
-                            },
-                            Object {
-                              "id": 2,
-                              "illustrationSource": "462695757",
-                              "illustrationType": "vimeo",
-                              "subtitle": "This is a subtitle",
-                              "title": "Last step",
-                            },
-                          ],
-                          "title": "Fitness Drill Title",
-                          "type": "fitness",
-                        },
-                        Object {
-                          "author": "Author",
-                          "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec scelerisque dignissim felis, at tristique mi efficitur a. Nulla pellentesque odio nunc, ut sodales ex pulvinar at. In hac habitasse platea dictumst. Pellentesque sodales nisl lorem, ac lacinia nisl lacinia eu. Proin lacinia viverra mauris, et pharetra ipsum tempus eget. Ut maximus sapien in hendrerit ultricies. Maecenas vel diam tincidunt, consequat nunc a, mattis eros. Curabitur a eros a nulla malesuada gravida. Donec massa quam, suscipit eget efficitur et, euismod sed nulla. Morbi mattis et magna a aliquam. Fusce pellentesque vel erat eget",
-                          "durationInMinutes": 30,
-                          "equipment": "Equipment needs for the drill",
-                          "equipmentLabel": "",
-                          "goals": Array [
-                            "Defense",
-                          ],
-                          "id": 3,
-                          "image": "https://i1.wp.com/www.newdelhitimes.com/wp-content/uploads/2019/07/AP19204604544330.jpg?w=1024&ssl=1",
-                          "intensity": "Low",
-                          "level": "Beginner",
-                          "minimalPlayersNumber": 2,
-                          "seasonTiming": "",
-                          "steps": Array [
-                            Object {
-                              "id": 0,
-                              "illustrationSource": Object {
-                                "ids": Array [
-                                  "triangle",
-                                  "triangle",
-                                  "triangle",
-                                  "triangle",
-                                  "triangle",
-                                  "triangle",
-                                  "triangle",
-                                  "triangle",
-                                  "offense",
-                                  "offense",
-                                  "offense",
-                                  "offense",
-                                  "offense",
-                                  "disc",
-                                ],
-                                "positions": Array [
+                    "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec scelerisque dignissim felis, at tristique mi efficitur a. Nulla pellentesque odio nunc, ut sodales ex pulvinar at. In hac habitasse platea dictumst. Pellentesque sodales nisl lorem, ac lacinia nisl lacinia eu. Proin lacinia viverra mauris, et pharetra ipsum tempus eget. Ut maximus sapien in hendrerit ultricies. Maecenas vel diam tincidunt, consequat nunc a, mattis eros. Curabitur a eros a nulla malesuada gravida. Donec massa quam, suscipit eget efficitur et, euismod sed nulla. Morbi mattis et magna a aliquam. Fusce pellentesque vel erat eget",
+                    "drills": Array [
+                      Object {
+                        "author": "Author",
+                        "description": "Description of the drill",
+                        "durationInMinutes": 10,
+                        "equipment": "Equipment needs for the drill",
+                        "equipmentLabel": "Full",
+                        "goals": Array [
+                          "Legs",
+                        ],
+                        "id": 2,
+                        "image": "http://www.liberte-fitness.fr/sites/default/files/styles/slider/public/news/tone.jpg?itok=505bme2a",
+                        "intensity": "High",
+                        "level": "Intermediate",
+                        "minimalPlayersNumber": 1,
+                        "seasonTiming": "In-season",
+                        "steps": Array [
+                          Object {
+                            "id": 0,
+                            "illustrationSource": "462695757",
+                            "illustrationType": "vimeo",
+                            "subtitle": "This is a subtitle",
+                            "title": "Warmup",
+                          },
+                          Object {
+                            "id": 1,
+                            "illustrationSource": "462695757",
+                            "illustrationType": "vimeo",
+                            "subtitle": "This is a subtitle",
+                            "title": "Do the drill",
+                          },
+                          Object {
+                            "id": 2,
+                            "illustrationSource": "462695757",
+                            "illustrationType": "vimeo",
+                            "subtitle": "This is a subtitle",
+                            "title": "Last step",
+                          },
+                        ],
+                        "title": "Fitness Drill Title",
+                        "type": "fitness",
+                      },
+                      Object {
+                        "author": "Author",
+                        "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec scelerisque dignissim felis, at tristique mi efficitur a. Nulla pellentesque odio nunc, ut sodales ex pulvinar at. In hac habitasse platea dictumst. Pellentesque sodales nisl lorem, ac lacinia nisl lacinia eu. Proin lacinia viverra mauris, et pharetra ipsum tempus eget. Ut maximus sapien in hendrerit ultricies. Maecenas vel diam tincidunt, consequat nunc a, mattis eros. Curabitur a eros a nulla malesuada gravida. Donec massa quam, suscipit eget efficitur et, euismod sed nulla. Morbi mattis et magna a aliquam. Fusce pellentesque vel erat eget",
+                        "durationInMinutes": 30,
+                        "equipment": "Equipment needs for the drill",
+                        "equipmentLabel": "",
+                        "goals": Array [
+                          "Defense",
+                        ],
+                        "id": 3,
+                        "image": "https://i1.wp.com/www.newdelhitimes.com/wp-content/uploads/2019/07/AP19204604544330.jpg?w=1024&ssl=1",
+                        "intensity": "Low",
+                        "level": "Beginner",
+                        "minimalPlayersNumber": 2,
+                        "seasonTiming": "",
+                        "steps": Array [
+                          Object {
+                            "id": 0,
+                            "illustrationSource": Object {
+                              "ids": Array [
+                                "triangle",
+                                "triangle",
+                                "triangle",
+                                "triangle",
+                                "triangle",
+                                "triangle",
+                                "triangle",
+                                "triangle",
+                                "offense",
+                                "offense",
+                                "offense",
+                                "offense",
+                                "offense",
+                                "disc",
+                              ],
+                              "positions": Array [
+                                Array [
                                   Array [
                                     Array [
-                                      Array [
-                                        0.3,
-                                        0.3,
-                                      ],
-                                    ],
-                                    Array [
-                                      Array [
-                                        0.3,
-                                        0.6,
-                                      ],
-                                    ],
-                                    Array [
-                                      Array [
-                                        0.6,
-                                        0.3,
-                                      ],
-                                    ],
-                                    Array [
-                                      Array [
-                                        0.6,
-                                        0.6,
-                                      ],
-                                    ],
-                                    Array [
-                                      Array [
-                                        0.45,
-                                        0.2,
-                                      ],
-                                    ],
-                                    Array [
-                                      Array [
-                                        0.2,
-                                        0.45,
-                                      ],
-                                    ],
-                                    Array [
-                                      Array [
-                                        0.45,
-                                        0.7,
-                                      ],
-                                    ],
-                                    Array [
-                                      Array [
-                                        0.7,
-                                        0.45,
-                                      ],
-                                    ],
-                                    Array [
-                                      Array [
-                                        0.3,
-                                        0.3,
-                                      ],
-                                    ],
-                                    Array [
-                                      Array [
-                                        0.16,
-                                        0.3,
-                                      ],
-                                    ],
-                                    Array [
-                                      Array [
-                                        0.6,
-                                        0.3,
-                                      ],
-                                    ],
-                                    Array [
-                                      Array [
-                                        0.6,
-                                        0.6,
-                                      ],
-                                    ],
-                                    Array [
-                                      Array [
-                                        0.3,
-                                        0.6,
-                                      ],
-                                    ],
-                                    Array [
-                                      Array [
-                                        0.36,
-                                        0.36,
-                                      ],
+                                      0.3,
+                                      0.3,
                                     ],
                                   ],
                                   Array [
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
                                     Array [
-                                      Array [
-                                        0.45,
-                                        0.2,
-                                      ],
-                                    ],
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                  ],
-                                  Array [
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    Array [
-                                      Array [
-                                        0.6,
-                                        0.3,
-                                      ],
-                                    ],
-                                    Array [
-                                      Array [
-                                        0.7,
-                                        0.45,
-                                      ],
-                                    ],
-                                    undefined,
-                                    undefined,
-                                    Array [
-                                      Array [
-                                        0.58,
-                                        0.36,
-                                      ],
+                                      0.3,
+                                      0.6,
                                     ],
                                   ],
                                   Array [
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
                                     Array [
-                                      Array [
-                                        0.6,
-                                        0.6,
-                                      ],
-                                    ],
-                                    Array [
-                                      Array [
-                                        0.45,
-                                        0.7,
-                                      ],
-                                    ],
-                                    undefined,
-                                    Array [
-                                      Array [
-                                        0.58,
-                                        0.58,
-                                      ],
+                                      0.6,
+                                      0.3,
                                     ],
                                   ],
                                   Array [
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
                                     Array [
-                                      Array [
-                                        0.3,
-                                        0.6,
-                                      ],
-                                    ],
-                                    Array [
-                                      Array [
-                                        0.2,
-                                        0.45,
-                                      ],
-                                    ],
-                                    Array [
-                                      Array [
-                                        0.36,
-                                        0.58,
-                                      ],
+                                      0.6,
+                                      0.6,
                                     ],
                                   ],
                                   Array [
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
                                     Array [
-                                      Array [
-                                        0.45,
-                                        0.2,
-                                      ],
+                                      0.45,
+                                      0.2,
                                     ],
-                                    undefined,
-                                    undefined,
-                                    undefined,
+                                  ],
+                                  Array [
                                     Array [
-                                      Array [
-                                        0.3,
-                                        0.3,
-                                      ],
+                                      0.2,
+                                      0.45,
                                     ],
+                                  ],
+                                  Array [
                                     Array [
-                                      Array [
-                                        0.36,
-                                        0.36,
-                                      ],
+                                      0.45,
+                                      0.7,
+                                    ],
+                                  ],
+                                  Array [
+                                    Array [
+                                      0.7,
+                                      0.45,
+                                    ],
+                                  ],
+                                  Array [
+                                    Array [
+                                      0.3,
+                                      0.3,
+                                    ],
+                                  ],
+                                  Array [
+                                    Array [
+                                      0.16,
+                                      0.3,
+                                    ],
+                                  ],
+                                  Array [
+                                    Array [
+                                      0.6,
+                                      0.3,
+                                    ],
+                                  ],
+                                  Array [
+                                    Array [
+                                      0.6,
+                                      0.6,
+                                    ],
+                                  ],
+                                  Array [
+                                    Array [
+                                      0.3,
+                                      0.6,
+                                    ],
+                                  ],
+                                  Array [
+                                    Array [
+                                      0.36,
+                                      0.36,
                                     ],
                                   ],
                                 ],
-                                "texts": Array [
-                                  "",
-                                  "",
-                                  "",
-                                  "",
-                                  "",
-                                  "",
-                                  "",
-                                  "",
-                                  "1",
-                                  "2",
-                                  "3",
-                                  "4",
-                                  "5",
-                                  "",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  Array [
+                                    Array [
+                                      0.45,
+                                      0.2,
+                                    ],
+                                  ],
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
                                 ],
-                              },
-                              "illustrationType": "animation",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  Array [
+                                    Array [
+                                      0.6,
+                                      0.3,
+                                    ],
+                                  ],
+                                  Array [
+                                    Array [
+                                      0.7,
+                                      0.45,
+                                    ],
+                                  ],
+                                  undefined,
+                                  undefined,
+                                  Array [
+                                    Array [
+                                      0.58,
+                                      0.36,
+                                    ],
+                                  ],
+                                ],
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  Array [
+                                    Array [
+                                      0.6,
+                                      0.6,
+                                    ],
+                                  ],
+                                  Array [
+                                    Array [
+                                      0.45,
+                                      0.7,
+                                    ],
+                                  ],
+                                  undefined,
+                                  Array [
+                                    Array [
+                                      0.58,
+                                      0.58,
+                                    ],
+                                  ],
+                                ],
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  Array [
+                                    Array [
+                                      0.3,
+                                      0.6,
+                                    ],
+                                  ],
+                                  Array [
+                                    Array [
+                                      0.2,
+                                      0.45,
+                                    ],
+                                  ],
+                                  Array [
+                                    Array [
+                                      0.36,
+                                      0.58,
+                                    ],
+                                  ],
+                                ],
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  Array [
+                                    Array [
+                                      0.45,
+                                      0.2,
+                                    ],
+                                  ],
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  Array [
+                                    Array [
+                                      0.3,
+                                      0.3,
+                                    ],
+                                  ],
+                                  Array [
+                                    Array [
+                                      0.36,
+                                      0.36,
+                                    ],
+                                  ],
+                                ],
+                              ],
+                              "texts": Array [
+                                "",
+                                "",
+                                "",
+                                "",
+                                "",
+                                "",
+                                "",
+                                "",
+                                "1",
+                                "2",
+                                "3",
+                                "4",
+                                "5",
+                                "",
+                              ],
                             },
-                          ],
-                          "title": "Frisbee Drill Title",
-                          "type": "frisbee",
-                        },
-                      ],
-                      "id": 1,
-                      "illustrationSource": "Rise Up",
-                      "image": "https://d3j2bju5c7tc02.cloudfront.net/2016_44/backhand.jpg",
-                      "title": "Dump & Swing",
-                    },
-                    Object {
-                      "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec scelerisque dignissim felis, at tristique mi efficitur a. Nulla pellentesque odio nunc, ut sodales ex pulvinar at. In hac habitasse platea dictumst. Pellentesque sodales nisl lorem, ac lacinia nisl lacinia eu. Proin lacinia viverra mauris, et pharetra ipsum tempus eget. Ut maximus sapien in hendrerit ultricies. Maecenas vel diam tincidunt, consequat nunc a, mattis eros. Curabitur a eros a nulla malesuada gravida. Donec massa quam, suscipit eget efficitur et, euismod sed nulla. Morbi mattis et magna a aliquam. Fusce pellentesque vel erat eget",
-                      "drills": Array [
-                        Object {
-                          "author": "Author",
-                          "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec scelerisque dignissim felis, at tristique mi efficitur a. Nulla pellentesque odio nunc, ut sodales ex pulvinar at. In hac habitasse platea dictumst. Pellentesque sodales nisl lorem, ac lacinia nisl lacinia eu. Proin lacinia viverra mauris, et pharetra ipsum tempus eget. Ut maximus sapien in hendrerit ultricies. Maecenas vel diam tincidunt, consequat nunc a, mattis eros. Curabitur a eros a nulla malesuada gravida. Donec massa quam, suscipit eget efficitur et, euismod sed nulla. Morbi mattis et magna a aliquam. Fusce pellentesque vel erat eget",
-                          "durationInMinutes": 30,
-                          "equipment": "Equipment needs for the drill",
-                          "equipmentLabel": "",
-                          "goals": Array [
-                            "Defense",
-                          ],
-                          "id": 3,
-                          "image": "https://i1.wp.com/www.newdelhitimes.com/wp-content/uploads/2019/07/AP19204604544330.jpg?w=1024&ssl=1",
-                          "intensity": "Low",
-                          "level": "Beginner",
-                          "minimalPlayersNumber": 2,
-                          "seasonTiming": "",
-                          "steps": Array [
-                            Object {
-                              "id": 0,
-                              "illustrationSource": Object {
-                                "ids": Array [
-                                  "triangle",
-                                  "triangle",
-                                  "triangle",
-                                  "triangle",
-                                  "triangle",
-                                  "triangle",
-                                  "triangle",
-                                  "triangle",
-                                  "offense",
-                                  "offense",
-                                  "offense",
-                                  "offense",
-                                  "offense",
-                                  "disc",
-                                ],
-                                "positions": Array [
+                            "illustrationType": "animation",
+                          },
+                        ],
+                        "title": "Frisbee Drill Title",
+                        "type": "frisbee",
+                      },
+                    ],
+                    "id": 1,
+                    "illustrationSource": "Rise Up",
+                    "image": "https://d3j2bju5c7tc02.cloudfront.net/2016_44/backhand.jpg",
+                    "title": "Dump & Swing",
+                  },
+                  Object {
+                    "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec scelerisque dignissim felis, at tristique mi efficitur a. Nulla pellentesque odio nunc, ut sodales ex pulvinar at. In hac habitasse platea dictumst. Pellentesque sodales nisl lorem, ac lacinia nisl lacinia eu. Proin lacinia viverra mauris, et pharetra ipsum tempus eget. Ut maximus sapien in hendrerit ultricies. Maecenas vel diam tincidunt, consequat nunc a, mattis eros. Curabitur a eros a nulla malesuada gravida. Donec massa quam, suscipit eget efficitur et, euismod sed nulla. Morbi mattis et magna a aliquam. Fusce pellentesque vel erat eget",
+                    "drills": Array [
+                      Object {
+                        "author": "Author",
+                        "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec scelerisque dignissim felis, at tristique mi efficitur a. Nulla pellentesque odio nunc, ut sodales ex pulvinar at. In hac habitasse platea dictumst. Pellentesque sodales nisl lorem, ac lacinia nisl lacinia eu. Proin lacinia viverra mauris, et pharetra ipsum tempus eget. Ut maximus sapien in hendrerit ultricies. Maecenas vel diam tincidunt, consequat nunc a, mattis eros. Curabitur a eros a nulla malesuada gravida. Donec massa quam, suscipit eget efficitur et, euismod sed nulla. Morbi mattis et magna a aliquam. Fusce pellentesque vel erat eget",
+                        "durationInMinutes": 30,
+                        "equipment": "Equipment needs for the drill",
+                        "equipmentLabel": "",
+                        "goals": Array [
+                          "Defense",
+                        ],
+                        "id": 3,
+                        "image": "https://i1.wp.com/www.newdelhitimes.com/wp-content/uploads/2019/07/AP19204604544330.jpg?w=1024&ssl=1",
+                        "intensity": "Low",
+                        "level": "Beginner",
+                        "minimalPlayersNumber": 2,
+                        "seasonTiming": "",
+                        "steps": Array [
+                          Object {
+                            "id": 0,
+                            "illustrationSource": Object {
+                              "ids": Array [
+                                "triangle",
+                                "triangle",
+                                "triangle",
+                                "triangle",
+                                "triangle",
+                                "triangle",
+                                "triangle",
+                                "triangle",
+                                "offense",
+                                "offense",
+                                "offense",
+                                "offense",
+                                "offense",
+                                "disc",
+                              ],
+                              "positions": Array [
+                                Array [
                                   Array [
                                     Array [
-                                      Array [
-                                        0.3,
-                                        0.3,
-                                      ],
-                                    ],
-                                    Array [
-                                      Array [
-                                        0.3,
-                                        0.6,
-                                      ],
-                                    ],
-                                    Array [
-                                      Array [
-                                        0.6,
-                                        0.3,
-                                      ],
-                                    ],
-                                    Array [
-                                      Array [
-                                        0.6,
-                                        0.6,
-                                      ],
-                                    ],
-                                    Array [
-                                      Array [
-                                        0.45,
-                                        0.2,
-                                      ],
-                                    ],
-                                    Array [
-                                      Array [
-                                        0.2,
-                                        0.45,
-                                      ],
-                                    ],
-                                    Array [
-                                      Array [
-                                        0.45,
-                                        0.7,
-                                      ],
-                                    ],
-                                    Array [
-                                      Array [
-                                        0.7,
-                                        0.45,
-                                      ],
-                                    ],
-                                    Array [
-                                      Array [
-                                        0.3,
-                                        0.3,
-                                      ],
-                                    ],
-                                    Array [
-                                      Array [
-                                        0.16,
-                                        0.3,
-                                      ],
-                                    ],
-                                    Array [
-                                      Array [
-                                        0.6,
-                                        0.3,
-                                      ],
-                                    ],
-                                    Array [
-                                      Array [
-                                        0.6,
-                                        0.6,
-                                      ],
-                                    ],
-                                    Array [
-                                      Array [
-                                        0.3,
-                                        0.6,
-                                      ],
-                                    ],
-                                    Array [
-                                      Array [
-                                        0.36,
-                                        0.36,
-                                      ],
+                                      0.3,
+                                      0.3,
                                     ],
                                   ],
                                   Array [
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
                                     Array [
-                                      Array [
-                                        0.45,
-                                        0.2,
-                                      ],
-                                    ],
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                  ],
-                                  Array [
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    Array [
-                                      Array [
-                                        0.6,
-                                        0.3,
-                                      ],
-                                    ],
-                                    Array [
-                                      Array [
-                                        0.7,
-                                        0.45,
-                                      ],
-                                    ],
-                                    undefined,
-                                    undefined,
-                                    Array [
-                                      Array [
-                                        0.58,
-                                        0.36,
-                                      ],
+                                      0.3,
+                                      0.6,
                                     ],
                                   ],
                                   Array [
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
                                     Array [
-                                      Array [
-                                        0.6,
-                                        0.6,
-                                      ],
-                                    ],
-                                    Array [
-                                      Array [
-                                        0.45,
-                                        0.7,
-                                      ],
-                                    ],
-                                    undefined,
-                                    Array [
-                                      Array [
-                                        0.58,
-                                        0.58,
-                                      ],
+                                      0.6,
+                                      0.3,
                                     ],
                                   ],
                                   Array [
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
                                     Array [
-                                      Array [
-                                        0.3,
-                                        0.6,
-                                      ],
-                                    ],
-                                    Array [
-                                      Array [
-                                        0.2,
-                                        0.45,
-                                      ],
-                                    ],
-                                    Array [
-                                      Array [
-                                        0.36,
-                                        0.58,
-                                      ],
+                                      0.6,
+                                      0.6,
                                     ],
                                   ],
                                   Array [
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
                                     Array [
-                                      Array [
-                                        0.45,
-                                        0.2,
-                                      ],
+                                      0.45,
+                                      0.2,
                                     ],
-                                    undefined,
-                                    undefined,
-                                    undefined,
+                                  ],
+                                  Array [
                                     Array [
-                                      Array [
-                                        0.3,
-                                        0.3,
-                                      ],
+                                      0.2,
+                                      0.45,
                                     ],
+                                  ],
+                                  Array [
                                     Array [
-                                      Array [
-                                        0.36,
-                                        0.36,
-                                      ],
+                                      0.45,
+                                      0.7,
+                                    ],
+                                  ],
+                                  Array [
+                                    Array [
+                                      0.7,
+                                      0.45,
+                                    ],
+                                  ],
+                                  Array [
+                                    Array [
+                                      0.3,
+                                      0.3,
+                                    ],
+                                  ],
+                                  Array [
+                                    Array [
+                                      0.16,
+                                      0.3,
+                                    ],
+                                  ],
+                                  Array [
+                                    Array [
+                                      0.6,
+                                      0.3,
+                                    ],
+                                  ],
+                                  Array [
+                                    Array [
+                                      0.6,
+                                      0.6,
+                                    ],
+                                  ],
+                                  Array [
+                                    Array [
+                                      0.3,
+                                      0.6,
+                                    ],
+                                  ],
+                                  Array [
+                                    Array [
+                                      0.36,
+                                      0.36,
                                     ],
                                   ],
                                 ],
-                                "texts": Array [
-                                  "",
-                                  "",
-                                  "",
-                                  "",
-                                  "",
-                                  "",
-                                  "",
-                                  "",
-                                  "1",
-                                  "2",
-                                  "3",
-                                  "4",
-                                  "5",
-                                  "",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  Array [
+                                    Array [
+                                      0.45,
+                                      0.2,
+                                    ],
+                                  ],
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
                                 ],
-                              },
-                              "illustrationType": "animation",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  Array [
+                                    Array [
+                                      0.6,
+                                      0.3,
+                                    ],
+                                  ],
+                                  Array [
+                                    Array [
+                                      0.7,
+                                      0.45,
+                                    ],
+                                  ],
+                                  undefined,
+                                  undefined,
+                                  Array [
+                                    Array [
+                                      0.58,
+                                      0.36,
+                                    ],
+                                  ],
+                                ],
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  Array [
+                                    Array [
+                                      0.6,
+                                      0.6,
+                                    ],
+                                  ],
+                                  Array [
+                                    Array [
+                                      0.45,
+                                      0.7,
+                                    ],
+                                  ],
+                                  undefined,
+                                  Array [
+                                    Array [
+                                      0.58,
+                                      0.58,
+                                    ],
+                                  ],
+                                ],
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  Array [
+                                    Array [
+                                      0.3,
+                                      0.6,
+                                    ],
+                                  ],
+                                  Array [
+                                    Array [
+                                      0.2,
+                                      0.45,
+                                    ],
+                                  ],
+                                  Array [
+                                    Array [
+                                      0.36,
+                                      0.58,
+                                    ],
+                                  ],
+                                ],
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  Array [
+                                    Array [
+                                      0.45,
+                                      0.2,
+                                    ],
+                                  ],
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  Array [
+                                    Array [
+                                      0.3,
+                                      0.3,
+                                    ],
+                                  ],
+                                  Array [
+                                    Array [
+                                      0.36,
+                                      0.36,
+                                    ],
+                                  ],
+                                ],
+                              ],
+                              "texts": Array [
+                                "",
+                                "",
+                                "",
+                                "",
+                                "",
+                                "",
+                                "",
+                                "",
+                                "1",
+                                "2",
+                                "3",
+                                "4",
+                                "5",
+                                "",
+                              ],
                             },
-                          ],
-                          "title": "Frisbee Drill Title",
-                          "type": "frisbee",
-                        },
-                        Object {
-                          "author": "Author",
-                          "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec scelerisque dignissim felis, at tristique mi efficitur a. Nulla pellentesque odio nunc, ut sodales ex pulvinar at. In hac habitasse platea dictumst. Pellentesque sodales nisl lorem, ac lacinia nisl lacinia eu. Proin lacinia viverra mauris, et pharetra ipsum tempus eget. Ut maximus sapien in hendrerit ultricies. Maecenas vel diam tincidunt, consequat nunc a, mattis eros. Curabitur a eros a nulla malesuada gravida. Donec massa quam, suscipit eget efficitur et, euismod sed nulla. Morbi mattis et magna a aliquam. Fusce pellentesque vel erat eget",
-                          "durationInMinutes": 30,
-                          "equipment": "Equipment needs for the drill",
-                          "equipmentLabel": "",
-                          "goals": Array [
-                            "Defense",
-                          ],
-                          "id": 4,
-                          "image": "https://www.plu.edu/recreations/wp-content/uploads/sites/197/2019/04/ultimate-frisbee-3-2-19-1122-scaled-1536x1163.jpg",
-                          "intensity": "Low",
-                          "level": "Beginner",
-                          "minimalPlayersNumber": 2,
-                          "seasonTiming": "",
-                          "steps": Array [
-                            Object {
-                              "id": 0,
-                              "illustrationSource": "462695757",
-                              "illustrationType": "vimeo",
-                            },
-                          ],
-                          "title": "Frisbee Drill Title",
-                          "type": "frisbee",
-                        },
-                      ],
-                      "id": 2,
-                      "illustrationSource": "Rise Up",
-                      "image": "https://d3j2bju5c7tc02.cloudfront.net/2016_44/backhand.jpg",
-                      "title": "Training 2",
-                    },
-                  ]
-                }
-                disableVirtualization={false}
-                getItem={[Function]}
-                getItemCount={[Function]}
-                horizontal={false}
-                initialNumToRender={10}
-                keyExtractor={[Function]}
-                maxToRenderPerBatch={10}
-                onContentSizeChange={[Function]}
-                onEndReachedThreshold={2}
-                onLayout={[Function]}
-                onMomentumScrollEnd={[Function]}
-                onScroll={[Function]}
-                onScrollBeginDrag={[Function]}
-                onScrollEndDrag={[Function]}
-                removeClippedSubviews={false}
-                renderItem={[Function]}
-                scrollEventThrottle={50}
-                stickyHeaderIndices={Array []}
-                updateCellsBatchingPeriod={50}
-                viewabilityConfigCallbackPairs={Array []}
-                windowSize={21}
-              >
-                <View>
+                            "illustrationType": "animation",
+                          },
+                        ],
+                        "title": "Frisbee Drill Title",
+                        "type": "frisbee",
+                      },
+                      Object {
+                        "author": "Author",
+                        "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec scelerisque dignissim felis, at tristique mi efficitur a. Nulla pellentesque odio nunc, ut sodales ex pulvinar at. In hac habitasse platea dictumst. Pellentesque sodales nisl lorem, ac lacinia nisl lacinia eu. Proin lacinia viverra mauris, et pharetra ipsum tempus eget. Ut maximus sapien in hendrerit ultricies. Maecenas vel diam tincidunt, consequat nunc a, mattis eros. Curabitur a eros a nulla malesuada gravida. Donec massa quam, suscipit eget efficitur et, euismod sed nulla. Morbi mattis et magna a aliquam. Fusce pellentesque vel erat eget",
+                        "durationInMinutes": 30,
+                        "equipment": "Equipment needs for the drill",
+                        "equipmentLabel": "",
+                        "goals": Array [
+                          "Defense",
+                        ],
+                        "id": 4,
+                        "image": "https://www.plu.edu/recreations/wp-content/uploads/sites/197/2019/04/ultimate-frisbee-3-2-19-1122-scaled-1536x1163.jpg",
+                        "intensity": "Low",
+                        "level": "Beginner",
+                        "minimalPlayersNumber": 2,
+                        "seasonTiming": "",
+                        "steps": Array [
+                          Object {
+                            "id": 0,
+                            "illustrationSource": "462695757",
+                            "illustrationType": "vimeo",
+                          },
+                        ],
+                        "title": "Frisbee Drill Title",
+                        "type": "frisbee",
+                      },
+                    ],
+                    "id": 2,
+                    "illustrationSource": "Rise Up",
+                    "image": "https://d3j2bju5c7tc02.cloudfront.net/2016_44/backhand.jpg",
+                    "title": "Training 2",
+                  },
+                ]
+              }
+              disableVirtualization={false}
+              getItem={[Function]}
+              getItemCount={[Function]}
+              horizontal={false}
+              initialNumToRender={10}
+              keyExtractor={[Function]}
+              maxToRenderPerBatch={10}
+              onContentSizeChange={[Function]}
+              onEndReachedThreshold={2}
+              onLayout={[Function]}
+              onMomentumScrollEnd={[Function]}
+              onScroll={[Function]}
+              onScrollBeginDrag={[Function]}
+              onScrollEndDrag={[Function]}
+              removeClippedSubviews={false}
+              renderItem={[Function]}
+              scrollEventThrottle={50}
+              stickyHeaderIndices={Array []}
+              updateCellsBatchingPeriod={50}
+              viewabilityConfigCallbackPairs={Array []}
+              windowSize={21}
+            >
+              <View>
+                <View
+                  onLayout={[Function]}
+                  style={null}
+                >
                   <View
-                    onLayout={[Function]}
-                    style={null}
+                    accessible={true}
+                    focusable={true}
+                    onClick={[Function]}
+                    onResponderGrant={[Function]}
+                    onResponderMove={[Function]}
+                    onResponderRelease={[Function]}
+                    onResponderTerminate={[Function]}
+                    onResponderTerminationRequest={[Function]}
+                    onStartShouldSetResponder={[Function]}
+                    style={
+                      Object {
+                        "alignItems": "center",
+                        "backgroundColor": "#fff",
+                        "borderBottomColor": "#e5e5e5",
+                        "borderBottomWidth": 1,
+                        "flexDirection": "row",
+                        "justifyContent": "space-between",
+                        "opacity": 1,
+                        "padding": 10,
+                        "paddingLeft": 30,
+                      }
+                    }
                   >
                     <View
-                      accessible={true}
-                      focusable={true}
-                      onClick={[Function]}
-                      onResponderGrant={[Function]}
-                      onResponderMove={[Function]}
-                      onResponderRelease={[Function]}
-                      onResponderTerminate={[Function]}
-                      onResponderTerminationRequest={[Function]}
-                      onStartShouldSetResponder={[Function]}
                       style={
                         Object {
-                          "alignItems": "center",
-                          "backgroundColor": "#fff",
-                          "borderBottomColor": "#e5e5e5",
-                          "borderBottomWidth": 1,
-                          "flexDirection": "row",
-                          "justifyContent": "space-between",
-                          "opacity": 1,
-                          "padding": 10,
-                          "paddingLeft": 30,
+                          "flexBasis": "75%",
                         }
                       }
                     >
-                      <View
+                      <Text
                         style={
                           Object {
-                            "flexBasis": "75%",
+                            "color": "#232b2b",
+                            "fontSize": 16,
+                            "fontWeight": "bold",
                           }
                         }
                       >
-                        <Text
-                          style={
-                            Object {
-                              "color": "#232b2b",
-                              "fontSize": 16,
-                              "fontWeight": "bold",
-                            }
-                          }
-                        >
-                          1
-                           - 
-                          Dump & Swing
-                        </Text>
-                        <Text
-                          style={
-                            Object {
-                              "color": "#232b2b",
-                              "fontSize": 14,
-                            }
-                          }
-                        >
-                          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec scelerisque dignissim felis, at tristique mi efficitur a. Nulla pellentesque odio nunc, ut sodales ex pulvinar at. In hac habitasse platea dictumst. Pellentesque sodales nisl lorem, ac lacinia nisl lacinia eu. Proin lacinia viverra mauris, et pharetra ipsum tempus eget. Ut maximus sapien in hendrerit ultricies. Maecenas vel diam tincidunt, consequat nunc a, mattis eros. Curabitur a eros a nulla malesuada gravida. Donec massa quam, suscipit eget efficitur et, euismod sed nulla. Morbi mattis et magna a aliquam. Fusce pellentesque vel erat eget
-                        </Text>
-                      </View>
-                      <View
+                        1
+                         - 
+                        Dump & Swing
+                      </Text>
+                      <Text
                         style={
                           Object {
-                            "position": "absolute",
-                            "right": 30,
+                            "color": "#232b2b",
+                            "fontSize": 14,
                           }
                         }
                       >
-                        <View
-                          style={
-                            Object {
-                              "alignItems": "center",
-                              "flexDirection": "row",
-                              "justifyContent": "space-between",
-                            }
-                          }
-                        >
-                          <Text />
-                        </View>
-                      </View>
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec scelerisque dignissim felis, at tristique mi efficitur a. Nulla pellentesque odio nunc, ut sodales ex pulvinar at. In hac habitasse platea dictumst. Pellentesque sodales nisl lorem, ac lacinia nisl lacinia eu. Proin lacinia viverra mauris, et pharetra ipsum tempus eget. Ut maximus sapien in hendrerit ultricies. Maecenas vel diam tincidunt, consequat nunc a, mattis eros. Curabitur a eros a nulla malesuada gravida. Donec massa quam, suscipit eget efficitur et, euismod sed nulla. Morbi mattis et magna a aliquam. Fusce pellentesque vel erat eget
+                      </Text>
                     </View>
-                  </View>
-                  <View
-                    onLayout={[Function]}
-                    style={null}
-                  >
                     <View
-                      accessible={true}
-                      focusable={true}
-                      onClick={[Function]}
-                      onResponderGrant={[Function]}
-                      onResponderMove={[Function]}
-                      onResponderRelease={[Function]}
-                      onResponderTerminate={[Function]}
-                      onResponderTerminationRequest={[Function]}
-                      onStartShouldSetResponder={[Function]}
                       style={
                         Object {
-                          "alignItems": "center",
-                          "backgroundColor": "#fff",
-                          "borderBottomColor": "#e5e5e5",
-                          "borderBottomWidth": 1,
-                          "flexDirection": "row",
-                          "justifyContent": "space-between",
-                          "opacity": 1,
-                          "padding": 10,
-                          "paddingLeft": 30,
+                          "position": "absolute",
+                          "right": 30,
                         }
                       }
                     >
                       <View
                         style={
                           Object {
-                            "flexBasis": "75%",
+                            "alignItems": "center",
+                            "flexDirection": "row",
+                            "justifyContent": "space-between",
                           }
                         }
                       >
-                        <Text
-                          style={
-                            Object {
-                              "color": "#232b2b",
-                              "fontSize": 16,
-                              "fontWeight": "bold",
-                            }
-                          }
-                        >
-                          2
-                           - 
-                          Training 2
-                        </Text>
-                        <Text
-                          style={
-                            Object {
-                              "color": "#232b2b",
-                              "fontSize": 14,
-                            }
-                          }
-                        >
-                          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec scelerisque dignissim felis, at tristique mi efficitur a. Nulla pellentesque odio nunc, ut sodales ex pulvinar at. In hac habitasse platea dictumst. Pellentesque sodales nisl lorem, ac lacinia nisl lacinia eu. Proin lacinia viverra mauris, et pharetra ipsum tempus eget. Ut maximus sapien in hendrerit ultricies. Maecenas vel diam tincidunt, consequat nunc a, mattis eros. Curabitur a eros a nulla malesuada gravida. Donec massa quam, suscipit eget efficitur et, euismod sed nulla. Morbi mattis et magna a aliquam. Fusce pellentesque vel erat eget
-                        </Text>
-                      </View>
-                      <View
-                        style={
-                          Object {
-                            "position": "absolute",
-                            "right": 30,
-                          }
-                        }
-                      >
-                        <View
-                          style={
-                            Object {
-                              "alignItems": "center",
-                              "flexDirection": "row",
-                              "justifyContent": "space-between",
-                            }
-                          }
-                        >
-                          <Text />
-                        </View>
+                        <Text />
                       </View>
                     </View>
                   </View>
                 </View>
-              </RCTScrollView>
-            </View>
+                <View
+                  onLayout={[Function]}
+                  style={null}
+                >
+                  <View
+                    accessible={true}
+                    focusable={true}
+                    onClick={[Function]}
+                    onResponderGrant={[Function]}
+                    onResponderMove={[Function]}
+                    onResponderRelease={[Function]}
+                    onResponderTerminate={[Function]}
+                    onResponderTerminationRequest={[Function]}
+                    onStartShouldSetResponder={[Function]}
+                    style={
+                      Object {
+                        "alignItems": "center",
+                        "backgroundColor": "#fff",
+                        "borderBottomColor": "#e5e5e5",
+                        "borderBottomWidth": 1,
+                        "flexDirection": "row",
+                        "justifyContent": "space-between",
+                        "opacity": 1,
+                        "padding": 10,
+                        "paddingLeft": 30,
+                      }
+                    }
+                  >
+                    <View
+                      style={
+                        Object {
+                          "flexBasis": "75%",
+                        }
+                      }
+                    >
+                      <Text
+                        style={
+                          Object {
+                            "color": "#232b2b",
+                            "fontSize": 16,
+                            "fontWeight": "bold",
+                          }
+                        }
+                      >
+                        2
+                         - 
+                        Training 2
+                      </Text>
+                      <Text
+                        style={
+                          Object {
+                            "color": "#232b2b",
+                            "fontSize": 14,
+                          }
+                        }
+                      >
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec scelerisque dignissim felis, at tristique mi efficitur a. Nulla pellentesque odio nunc, ut sodales ex pulvinar at. In hac habitasse platea dictumst. Pellentesque sodales nisl lorem, ac lacinia nisl lacinia eu. Proin lacinia viverra mauris, et pharetra ipsum tempus eget. Ut maximus sapien in hendrerit ultricies. Maecenas vel diam tincidunt, consequat nunc a, mattis eros. Curabitur a eros a nulla malesuada gravida. Donec massa quam, suscipit eget efficitur et, euismod sed nulla. Morbi mattis et magna a aliquam. Fusce pellentesque vel erat eget
+                      </Text>
+                    </View>
+                    <View
+                      style={
+                        Object {
+                          "position": "absolute",
+                          "right": 30,
+                        }
+                      }
+                    >
+                      <View
+                        style={
+                          Object {
+                            "alignItems": "center",
+                            "flexDirection": "row",
+                            "justifyContent": "space-between",
+                          }
+                        }
+                      >
+                        <Text />
+                      </View>
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </RCTScrollView>
           </View>
         </View>
       </View>
     </View>
-  </RCTScrollView>
-</View>
+  </View>
+</RCTScrollView>
 `;

--- a/src/Components/programs/ProgramList.js
+++ b/src/Components/programs/ProgramList.js
@@ -69,20 +69,19 @@ const ProgramList = (props) => {
   };
 
   return (
-    <View style={styles.programList}>
-      <ScrollView>
-        <Accordion
-          activeSections={activeSections}
-          sections={displayedPrograms}
-          touchableComponent={TouchableOpacity}
-          expandMultiple={false}
-          renderHeader={renderHeader}
-          renderContent={renderContent}
-          duration={400}
-          onChange={setSections}
-        />
-      </ScrollView>
-    </View>
+    <ScrollView style={styles.programList}>
+      <Accordion
+        activeSections={activeSections}
+        sections={displayedPrograms}
+        touchableComponent={TouchableOpacity}
+        expandMultiple={false}
+        renderHeader={renderHeader}
+        renderContent={renderContent}
+        duration={400}
+        onChange={setSections}
+        containerStyle={styles.accordionContainerStyle}
+      />
+    </ScrollView>
   );
 };
 
@@ -91,10 +90,9 @@ export default ProgramList;
 const styles = StyleSheet.create({
   programList: {
     height: '100%',
-    paddingVertical: 10,
   },
-  accordion: {
-    height: '100%',
+  accordionContainerStyle: {
+    marginBottom: 10,
   },
   trainingsList: {
     marginBottom: 10,

--- a/src/Components/programs/__snapshots__/Program.test.js.snap
+++ b/src/Components/programs/__snapshots__/Program.test.js.snap
@@ -6,7 +6,7 @@ exports[`<Program /> renders correctly 1`] = `
     Object {
       "backgroundColor": "#fff",
       "elevation": 3,
-      "marginBottom": 10,
+      "marginTop": 10,
       "padding": 10,
       "shadowOffset": Object {
         "height": 1,
@@ -94,7 +94,7 @@ exports[`<Program /> renders correctly when finished 1`] = `
     Object {
       "backgroundColor": "#fff",
       "elevation": 3,
-      "marginBottom": 10,
+      "marginTop": 10,
       "padding": 10,
       "shadowOffset": Object {
         "height": 1,

--- a/src/Components/programs/__snapshots__/ProgramList.test.js.snap
+++ b/src/Components/programs/__snapshots__/ProgramList.test.js.snap
@@ -1,681 +1,684 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<ProgramList /> renders correctly 1`] = `
-<View
+<RCTScrollView
   style={
     Object {
       "height": "100%",
-      "paddingVertical": 10,
     }
   }
 >
-  <RCTScrollView>
-    <View>
-      <View>
+  <View>
+    <View
+      style={
+        Object {
+          "marginBottom": 10,
+        }
+      }
+    >
+      <View
+        style={Object {}}
+      >
         <View
-          style={Object {}}
+          accessible={true}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "opacity": 1,
+            }
+          }
         >
           <View
-            accessible={true}
-            focusable={true}
-            onClick={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             style={
               Object {
-                "opacity": 1,
+                "backgroundColor": "#fff",
+                "elevation": 3,
+                "marginTop": 10,
+                "padding": 10,
+                "shadowOffset": Object {
+                  "height": 1,
+                  "width": 0,
+                },
+                "shadowOpacity": 0.3,
+                "shadowRadius": 3,
               }
             }
           >
             <View
               style={
                 Object {
+                  "alignItems": "flex-start",
                   "backgroundColor": "#fff",
-                  "elevation": 3,
-                  "marginBottom": 10,
-                  "padding": 10,
-                  "shadowOffset": Object {
-                    "height": 1,
-                    "width": 0,
-                  },
-                  "shadowOpacity": 0.3,
-                  "shadowRadius": 3,
+                  "paddingHorizontal": 20,
+                  "paddingVertical": 10,
+                  "width": "100%",
                 }
               }
             >
-              <View
+              <Text
                 style={
                   Object {
-                    "alignItems": "flex-start",
-                    "backgroundColor": "#fff",
-                    "paddingHorizontal": 20,
-                    "paddingVertical": 10,
+                    "color": "#232b2b",
+                    "fontSize": 20,
+                    "fontWeight": "bold",
+                  }
+                }
+              >
+                Program 1
+              </Text>
+              <Text
+                style={
+                  Object {
+                    "color": "#232b2b",
+                    "fontSize": 14,
+                    "textAlign": "right",
                     "width": "100%",
                   }
                 }
               >
-                <Text
-                  style={
-                    Object {
-                      "color": "#232b2b",
-                      "fontSize": 20,
-                      "fontWeight": "bold",
-                    }
+                0/1 trainings
+              </Text>
+              <View
+                style={
+                  Object {
+                    "backgroundColor": "#f1f1f1",
+                    "borderRadius": 2,
+                    "height": 3,
+                    "marginTop": 5,
+                    "width": "100%",
                   }
-                >
-                  Program 1
-                </Text>
-                <Text
-                  style={
-                    Object {
-                      "color": "#232b2b",
-                      "fontSize": 14,
-                      "textAlign": "right",
-                      "width": "100%",
-                    }
-                  }
-                >
-                  0/1 trainings
-                </Text>
+                }
+              >
                 <View
                   style={
-                    Object {
-                      "backgroundColor": "#f1f1f1",
-                      "borderRadius": 2,
-                      "height": 3,
-                      "marginTop": 5,
-                      "width": "100%",
-                    }
+                    Array [
+                      Object {
+                        "bottom": 0,
+                        "left": 0,
+                        "position": "absolute",
+                        "right": 0,
+                        "top": 0,
+                      },
+                      Object {
+                        "backgroundColor": "#2a9e91",
+                        "borderRadius": 5,
+                        "width": "50%",
+                      },
+                      Object {
+                        "width": "0%",
+                      },
+                    ]
                   }
-                >
-                  <View
-                    style={
-                      Array [
-                        Object {
-                          "bottom": 0,
-                          "left": 0,
-                          "position": "absolute",
-                          "right": 0,
-                          "top": 0,
-                        },
-                        Object {
-                          "backgroundColor": "#2a9e91",
-                          "borderRadius": 5,
-                          "width": "50%",
-                        },
-                        Object {
-                          "width": "0%",
-                        },
-                      ]
-                    }
-                  />
-                </View>
+                />
               </View>
-            </View>
-          </View>
-          <View
-            pointerEvents="none"
-            style={
-              Object {
-                "height": 0,
-                "overflow": "hidden",
-              }
-            }
-          >
-            <View
-              forwardedRef={[Function]}
-              onLayout={[Function]}
-              style={Object {}}
-            >
-              <RCTScrollView
-                contentContainerStyle={
-                  Object {
-                    "marginBottom": 10,
-                  }
-                }
-                data={
-                  Array [
-                    Object {
-                      "description": "This training session aims at..",
-                      "drills": Array [
-                        Object {
-                          "author": "Author",
-                          "description": "Description of the drill",
-                          "durationInMinutes": 10,
-                          "equipment": "Equipment needs for the drill",
-                          "equipmentLabel": "None",
-                          "goals": Array [
-                            "Full body",
-                          ],
-                          "id": 1,
-                          "image": "https://www.dialysistech.org/wp-content/uploads/2019/06/fitness.jpg",
-                          "intensity": "Low",
-                          "level": "Beginner",
-                          "minimalPlayersNumber": 1,
-                          "seasonTiming": "Off-season",
-                          "steps": Array [
-                            Object {
-                              "illustrationSource": "462695757",
-                              "illustrationType": "vimeo",
-                              "subtitle": "This is a subtitle",
-                              "title": "Warmup",
-                            },
-                          ],
-                          "title": "Fitness Drill Title",
-                          "type": "fitness",
-                        },
-                      ],
-                      "id": 1,
-                      "image": "https://cdn3.sportngin.com/attachments/photo/be7e-106813275/Screen_Shot_2018-07-19_at_3.53.39_PM_large.png",
-                      "source": "** Ultimate App **",
-                      "title": "First practice",
-                    },
-                  ]
-                }
-                disableVirtualization={false}
-                getItem={[Function]}
-                getItemCount={[Function]}
-                horizontal={false}
-                initialNumToRender={10}
-                keyExtractor={[Function]}
-                maxToRenderPerBatch={10}
-                onContentSizeChange={[Function]}
-                onEndReachedThreshold={2}
-                onLayout={[Function]}
-                onMomentumScrollEnd={[Function]}
-                onScroll={[Function]}
-                onScrollBeginDrag={[Function]}
-                onScrollEndDrag={[Function]}
-                removeClippedSubviews={false}
-                renderItem={[Function]}
-                scrollEventThrottle={50}
-                stickyHeaderIndices={Array []}
-                updateCellsBatchingPeriod={50}
-                viewabilityConfigCallbackPairs={Array []}
-                windowSize={21}
-              >
-                <View>
-                  <View
-                    onLayout={[Function]}
-                    style={null}
-                  >
-                    <View
-                      accessible={true}
-                      focusable={true}
-                      onClick={[Function]}
-                      onResponderGrant={[Function]}
-                      onResponderMove={[Function]}
-                      onResponderRelease={[Function]}
-                      onResponderTerminate={[Function]}
-                      onResponderTerminationRequest={[Function]}
-                      onStartShouldSetResponder={[Function]}
-                      style={
-                        Object {
-                          "alignItems": "center",
-                          "backgroundColor": "#fff",
-                          "borderBottomColor": "#e5e5e5",
-                          "borderBottomWidth": 1,
-                          "flexDirection": "row",
-                          "justifyContent": "space-between",
-                          "opacity": 1,
-                          "padding": 10,
-                          "paddingLeft": 30,
-                        }
-                      }
-                    >
-                      <View
-                        style={
-                          Object {
-                            "flexBasis": "75%",
-                          }
-                        }
-                      >
-                        <Text
-                          style={
-                            Object {
-                              "color": "#232b2b",
-                              "fontSize": 16,
-                              "fontWeight": "bold",
-                            }
-                          }
-                        >
-                          1
-                           - 
-                          First practice
-                        </Text>
-                        <Text
-                          style={
-                            Object {
-                              "color": "#232b2b",
-                              "fontSize": 14,
-                            }
-                          }
-                        >
-                          This training session aims at..
-                        </Text>
-                      </View>
-                      <View
-                        style={
-                          Object {
-                            "position": "absolute",
-                            "right": 30,
-                          }
-                        }
-                      >
-                        <View
-                          style={
-                            Object {
-                              "alignItems": "center",
-                              "flexDirection": "row",
-                              "justifyContent": "space-between",
-                            }
-                          }
-                        >
-                          <Text />
-                        </View>
-                      </View>
-                    </View>
-                  </View>
-                </View>
-              </RCTScrollView>
             </View>
           </View>
         </View>
         <View
-          style={Object {}}
+          pointerEvents="none"
+          style={
+            Object {
+              "height": 0,
+              "overflow": "hidden",
+            }
+          }
         >
           <View
-            accessible={true}
-            focusable={true}
-            onClick={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
+            forwardedRef={[Function]}
+            onLayout={[Function]}
+            style={Object {}}
+          >
+            <RCTScrollView
+              contentContainerStyle={
+                Object {
+                  "marginBottom": 10,
+                }
+              }
+              data={
+                Array [
+                  Object {
+                    "description": "This training session aims at..",
+                    "drills": Array [
+                      Object {
+                        "author": "Author",
+                        "description": "Description of the drill",
+                        "durationInMinutes": 10,
+                        "equipment": "Equipment needs for the drill",
+                        "equipmentLabel": "None",
+                        "goals": Array [
+                          "Full body",
+                        ],
+                        "id": 1,
+                        "image": "https://www.dialysistech.org/wp-content/uploads/2019/06/fitness.jpg",
+                        "intensity": "Low",
+                        "level": "Beginner",
+                        "minimalPlayersNumber": 1,
+                        "seasonTiming": "Off-season",
+                        "steps": Array [
+                          Object {
+                            "illustrationSource": "462695757",
+                            "illustrationType": "vimeo",
+                            "subtitle": "This is a subtitle",
+                            "title": "Warmup",
+                          },
+                        ],
+                        "title": "Fitness Drill Title",
+                        "type": "fitness",
+                      },
+                    ],
+                    "id": 1,
+                    "image": "https://cdn3.sportngin.com/attachments/photo/be7e-106813275/Screen_Shot_2018-07-19_at_3.53.39_PM_large.png",
+                    "source": "** Ultimate App **",
+                    "title": "First practice",
+                  },
+                ]
+              }
+              disableVirtualization={false}
+              getItem={[Function]}
+              getItemCount={[Function]}
+              horizontal={false}
+              initialNumToRender={10}
+              keyExtractor={[Function]}
+              maxToRenderPerBatch={10}
+              onContentSizeChange={[Function]}
+              onEndReachedThreshold={2}
+              onLayout={[Function]}
+              onMomentumScrollEnd={[Function]}
+              onScroll={[Function]}
+              onScrollBeginDrag={[Function]}
+              onScrollEndDrag={[Function]}
+              removeClippedSubviews={false}
+              renderItem={[Function]}
+              scrollEventThrottle={50}
+              stickyHeaderIndices={Array []}
+              updateCellsBatchingPeriod={50}
+              viewabilityConfigCallbackPairs={Array []}
+              windowSize={21}
+            >
+              <View>
+                <View
+                  onLayout={[Function]}
+                  style={null}
+                >
+                  <View
+                    accessible={true}
+                    focusable={true}
+                    onClick={[Function]}
+                    onResponderGrant={[Function]}
+                    onResponderMove={[Function]}
+                    onResponderRelease={[Function]}
+                    onResponderTerminate={[Function]}
+                    onResponderTerminationRequest={[Function]}
+                    onStartShouldSetResponder={[Function]}
+                    style={
+                      Object {
+                        "alignItems": "center",
+                        "backgroundColor": "#fff",
+                        "borderBottomColor": "#e5e5e5",
+                        "borderBottomWidth": 1,
+                        "flexDirection": "row",
+                        "justifyContent": "space-between",
+                        "opacity": 1,
+                        "padding": 10,
+                        "paddingLeft": 30,
+                      }
+                    }
+                  >
+                    <View
+                      style={
+                        Object {
+                          "flexBasis": "75%",
+                        }
+                      }
+                    >
+                      <Text
+                        style={
+                          Object {
+                            "color": "#232b2b",
+                            "fontSize": 16,
+                            "fontWeight": "bold",
+                          }
+                        }
+                      >
+                        1
+                         - 
+                        First practice
+                      </Text>
+                      <Text
+                        style={
+                          Object {
+                            "color": "#232b2b",
+                            "fontSize": 14,
+                          }
+                        }
+                      >
+                        This training session aims at..
+                      </Text>
+                    </View>
+                    <View
+                      style={
+                        Object {
+                          "position": "absolute",
+                          "right": 30,
+                        }
+                      }
+                    >
+                      <View
+                        style={
+                          Object {
+                            "alignItems": "center",
+                            "flexDirection": "row",
+                            "justifyContent": "space-between",
+                          }
+                        }
+                      >
+                        <Text />
+                      </View>
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </RCTScrollView>
+          </View>
+        </View>
+      </View>
+      <View
+        style={Object {}}
+      >
+        <View
+          accessible={true}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "opacity": 1,
+            }
+          }
+        >
+          <View
             style={
               Object {
-                "opacity": 1,
+                "backgroundColor": "#fff",
+                "elevation": 3,
+                "marginTop": 10,
+                "padding": 10,
+                "shadowOffset": Object {
+                  "height": 1,
+                  "width": 0,
+                },
+                "shadowOpacity": 0.3,
+                "shadowRadius": 3,
               }
             }
           >
             <View
               style={
                 Object {
+                  "alignItems": "flex-start",
                   "backgroundColor": "#fff",
-                  "elevation": 3,
-                  "marginBottom": 10,
-                  "padding": 10,
-                  "shadowOffset": Object {
-                    "height": 1,
-                    "width": 0,
-                  },
-                  "shadowOpacity": 0.3,
-                  "shadowRadius": 3,
+                  "paddingHorizontal": 20,
+                  "paddingVertical": 10,
+                  "width": "100%",
                 }
               }
             >
-              <View
+              <Text
                 style={
                   Object {
-                    "alignItems": "flex-start",
-                    "backgroundColor": "#fff",
-                    "paddingHorizontal": 20,
-                    "paddingVertical": 10,
+                    "color": "#232b2b",
+                    "fontSize": 20,
+                    "fontWeight": "bold",
+                  }
+                }
+              >
+                Program 2
+              </Text>
+              <Text
+                style={
+                  Object {
+                    "color": "#232b2b",
+                    "fontSize": 14,
+                    "textAlign": "right",
                     "width": "100%",
                   }
                 }
               >
-                <Text
-                  style={
-                    Object {
-                      "color": "#232b2b",
-                      "fontSize": 20,
-                      "fontWeight": "bold",
-                    }
+                0/2 trainings
+              </Text>
+              <View
+                style={
+                  Object {
+                    "backgroundColor": "#f1f1f1",
+                    "borderRadius": 2,
+                    "height": 3,
+                    "marginTop": 5,
+                    "width": "100%",
                   }
-                >
-                  Program 2
-                </Text>
-                <Text
-                  style={
-                    Object {
-                      "color": "#232b2b",
-                      "fontSize": 14,
-                      "textAlign": "right",
-                      "width": "100%",
-                    }
-                  }
-                >
-                  0/2 trainings
-                </Text>
+                }
+              >
                 <View
                   style={
-                    Object {
-                      "backgroundColor": "#f1f1f1",
-                      "borderRadius": 2,
-                      "height": 3,
-                      "marginTop": 5,
-                      "width": "100%",
-                    }
+                    Array [
+                      Object {
+                        "bottom": 0,
+                        "left": 0,
+                        "position": "absolute",
+                        "right": 0,
+                        "top": 0,
+                      },
+                      Object {
+                        "backgroundColor": "#2a9e91",
+                        "borderRadius": 5,
+                        "width": "50%",
+                      },
+                      Object {
+                        "width": "0%",
+                      },
+                    ]
                   }
-                >
-                  <View
-                    style={
-                      Array [
-                        Object {
-                          "bottom": 0,
-                          "left": 0,
-                          "position": "absolute",
-                          "right": 0,
-                          "top": 0,
-                        },
-                        Object {
-                          "backgroundColor": "#2a9e91",
-                          "borderRadius": 5,
-                          "width": "50%",
-                        },
-                        Object {
-                          "width": "0%",
-                        },
-                      ]
-                    }
-                  />
-                </View>
+                />
               </View>
             </View>
           </View>
-          <View
-            pointerEvents="none"
-            style={
-              Object {
-                "height": 0,
-                "overflow": "hidden",
-              }
+        </View>
+        <View
+          pointerEvents="none"
+          style={
+            Object {
+              "height": 0,
+              "overflow": "hidden",
             }
+          }
+        >
+          <View
+            forwardedRef={[Function]}
+            onLayout={[Function]}
+            style={Object {}}
           >
-            <View
-              forwardedRef={[Function]}
-              onLayout={[Function]}
-              style={Object {}}
-            >
-              <RCTScrollView
-                contentContainerStyle={
+            <RCTScrollView
+              contentContainerStyle={
+                Object {
+                  "marginBottom": 10,
+                }
+              }
+              data={
+                Array [
                   Object {
-                    "marginBottom": 10,
-                  }
-                }
-                data={
-                  Array [
-                    Object {
-                      "description": "This training session aims at..",
-                      "drills": Array [
-                        Object {
-                          "author": "Author",
-                          "description": "Description of the drill",
-                          "durationInMinutes": 10,
-                          "equipment": "Equipment needs for the drill",
-                          "equipmentLabel": "None",
-                          "goals": Array [
-                            "Full body",
-                          ],
-                          "id": 1,
-                          "image": "https://www.dialysistech.org/wp-content/uploads/2019/06/fitness.jpg",
-                          "intensity": "Low",
-                          "level": "Beginner",
-                          "minimalPlayersNumber": 1,
-                          "seasonTiming": "Off-season",
-                          "steps": Array [
-                            Object {
-                              "illustrationSource": "462695757",
-                              "illustrationType": "vimeo",
-                              "subtitle": "This is a subtitle",
-                              "title": "Warmup",
-                            },
-                          ],
-                          "title": "Fitness Drill Title",
-                          "type": "fitness",
-                        },
-                      ],
-                      "id": 1,
-                      "image": "https://cdn3.sportngin.com/attachments/photo/be7e-106813275/Screen_Shot_2018-07-19_at_3.53.39_PM_large.png",
-                      "source": "** Ultimate App **",
-                      "title": "First Training",
-                    },
-                    Object {
-                      "description": "This training session aims at..",
-                      "drills": Array [
-                        Object {
-                          "author": "Author",
-                          "description": "Description of the drill",
-                          "durationInMinutes": 10,
-                          "equipment": "Equipment needs for the drill",
-                          "equipmentLabel": "None",
-                          "goals": Array [
-                            "Full body",
-                          ],
-                          "id": 1,
-                          "image": "https://www.dialysistech.org/wp-content/uploads/2019/06/fitness.jpg",
-                          "intensity": "Low",
-                          "level": "Beginner",
-                          "minimalPlayersNumber": 1,
-                          "seasonTiming": "Off-season",
-                          "steps": Array [
-                            Object {
-                              "illustrationSource": "462695757",
-                              "illustrationType": "vimeo",
-                              "subtitle": "This is a subtitle",
-                              "title": "Warmup",
-                            },
-                          ],
-                          "title": "Fitness Drill Title",
-                          "type": "fitness",
-                        },
-                      ],
-                      "id": 2,
-                      "image": "https://cdn3.sportngin.com/attachments/photo/be7e-106813275/Screen_Shot_2018-07-19_at_3.53.39_PM_large.png",
-                      "source": "** Ultimate App **",
-                      "title": "Second Training",
-                    },
-                  ]
-                }
-                disableVirtualization={false}
-                getItem={[Function]}
-                getItemCount={[Function]}
-                horizontal={false}
-                initialNumToRender={10}
-                keyExtractor={[Function]}
-                maxToRenderPerBatch={10}
-                onContentSizeChange={[Function]}
-                onEndReachedThreshold={2}
-                onLayout={[Function]}
-                onMomentumScrollEnd={[Function]}
-                onScroll={[Function]}
-                onScrollBeginDrag={[Function]}
-                onScrollEndDrag={[Function]}
-                removeClippedSubviews={false}
-                renderItem={[Function]}
-                scrollEventThrottle={50}
-                stickyHeaderIndices={Array []}
-                updateCellsBatchingPeriod={50}
-                viewabilityConfigCallbackPairs={Array []}
-                windowSize={21}
-              >
-                <View>
+                    "description": "This training session aims at..",
+                    "drills": Array [
+                      Object {
+                        "author": "Author",
+                        "description": "Description of the drill",
+                        "durationInMinutes": 10,
+                        "equipment": "Equipment needs for the drill",
+                        "equipmentLabel": "None",
+                        "goals": Array [
+                          "Full body",
+                        ],
+                        "id": 1,
+                        "image": "https://www.dialysistech.org/wp-content/uploads/2019/06/fitness.jpg",
+                        "intensity": "Low",
+                        "level": "Beginner",
+                        "minimalPlayersNumber": 1,
+                        "seasonTiming": "Off-season",
+                        "steps": Array [
+                          Object {
+                            "illustrationSource": "462695757",
+                            "illustrationType": "vimeo",
+                            "subtitle": "This is a subtitle",
+                            "title": "Warmup",
+                          },
+                        ],
+                        "title": "Fitness Drill Title",
+                        "type": "fitness",
+                      },
+                    ],
+                    "id": 1,
+                    "image": "https://cdn3.sportngin.com/attachments/photo/be7e-106813275/Screen_Shot_2018-07-19_at_3.53.39_PM_large.png",
+                    "source": "** Ultimate App **",
+                    "title": "First Training",
+                  },
+                  Object {
+                    "description": "This training session aims at..",
+                    "drills": Array [
+                      Object {
+                        "author": "Author",
+                        "description": "Description of the drill",
+                        "durationInMinutes": 10,
+                        "equipment": "Equipment needs for the drill",
+                        "equipmentLabel": "None",
+                        "goals": Array [
+                          "Full body",
+                        ],
+                        "id": 1,
+                        "image": "https://www.dialysistech.org/wp-content/uploads/2019/06/fitness.jpg",
+                        "intensity": "Low",
+                        "level": "Beginner",
+                        "minimalPlayersNumber": 1,
+                        "seasonTiming": "Off-season",
+                        "steps": Array [
+                          Object {
+                            "illustrationSource": "462695757",
+                            "illustrationType": "vimeo",
+                            "subtitle": "This is a subtitle",
+                            "title": "Warmup",
+                          },
+                        ],
+                        "title": "Fitness Drill Title",
+                        "type": "fitness",
+                      },
+                    ],
+                    "id": 2,
+                    "image": "https://cdn3.sportngin.com/attachments/photo/be7e-106813275/Screen_Shot_2018-07-19_at_3.53.39_PM_large.png",
+                    "source": "** Ultimate App **",
+                    "title": "Second Training",
+                  },
+                ]
+              }
+              disableVirtualization={false}
+              getItem={[Function]}
+              getItemCount={[Function]}
+              horizontal={false}
+              initialNumToRender={10}
+              keyExtractor={[Function]}
+              maxToRenderPerBatch={10}
+              onContentSizeChange={[Function]}
+              onEndReachedThreshold={2}
+              onLayout={[Function]}
+              onMomentumScrollEnd={[Function]}
+              onScroll={[Function]}
+              onScrollBeginDrag={[Function]}
+              onScrollEndDrag={[Function]}
+              removeClippedSubviews={false}
+              renderItem={[Function]}
+              scrollEventThrottle={50}
+              stickyHeaderIndices={Array []}
+              updateCellsBatchingPeriod={50}
+              viewabilityConfigCallbackPairs={Array []}
+              windowSize={21}
+            >
+              <View>
+                <View
+                  onLayout={[Function]}
+                  style={null}
+                >
                   <View
-                    onLayout={[Function]}
-                    style={null}
+                    accessible={true}
+                    focusable={true}
+                    onClick={[Function]}
+                    onResponderGrant={[Function]}
+                    onResponderMove={[Function]}
+                    onResponderRelease={[Function]}
+                    onResponderTerminate={[Function]}
+                    onResponderTerminationRequest={[Function]}
+                    onStartShouldSetResponder={[Function]}
+                    style={
+                      Object {
+                        "alignItems": "center",
+                        "backgroundColor": "#fff",
+                        "borderBottomColor": "#e5e5e5",
+                        "borderBottomWidth": 1,
+                        "flexDirection": "row",
+                        "justifyContent": "space-between",
+                        "opacity": 1,
+                        "padding": 10,
+                        "paddingLeft": 30,
+                      }
+                    }
                   >
                     <View
-                      accessible={true}
-                      focusable={true}
-                      onClick={[Function]}
-                      onResponderGrant={[Function]}
-                      onResponderMove={[Function]}
-                      onResponderRelease={[Function]}
-                      onResponderTerminate={[Function]}
-                      onResponderTerminationRequest={[Function]}
-                      onStartShouldSetResponder={[Function]}
                       style={
                         Object {
-                          "alignItems": "center",
-                          "backgroundColor": "#fff",
-                          "borderBottomColor": "#e5e5e5",
-                          "borderBottomWidth": 1,
-                          "flexDirection": "row",
-                          "justifyContent": "space-between",
-                          "opacity": 1,
-                          "padding": 10,
-                          "paddingLeft": 30,
+                          "flexBasis": "75%",
                         }
                       }
                     >
-                      <View
+                      <Text
                         style={
                           Object {
-                            "flexBasis": "75%",
+                            "color": "#232b2b",
+                            "fontSize": 16,
+                            "fontWeight": "bold",
                           }
                         }
                       >
-                        <Text
-                          style={
-                            Object {
-                              "color": "#232b2b",
-                              "fontSize": 16,
-                              "fontWeight": "bold",
-                            }
-                          }
-                        >
-                          1
-                           - 
-                          First Training
-                        </Text>
-                        <Text
-                          style={
-                            Object {
-                              "color": "#232b2b",
-                              "fontSize": 14,
-                            }
-                          }
-                        >
-                          This training session aims at..
-                        </Text>
-                      </View>
-                      <View
+                        1
+                         - 
+                        First Training
+                      </Text>
+                      <Text
                         style={
                           Object {
-                            "position": "absolute",
-                            "right": 30,
+                            "color": "#232b2b",
+                            "fontSize": 14,
                           }
                         }
                       >
-                        <View
-                          style={
-                            Object {
-                              "alignItems": "center",
-                              "flexDirection": "row",
-                              "justifyContent": "space-between",
-                            }
-                          }
-                        >
-                          <Text />
-                        </View>
-                      </View>
+                        This training session aims at..
+                      </Text>
                     </View>
-                  </View>
-                  <View
-                    onLayout={[Function]}
-                    style={null}
-                  >
                     <View
-                      accessible={true}
-                      focusable={true}
-                      onClick={[Function]}
-                      onResponderGrant={[Function]}
-                      onResponderMove={[Function]}
-                      onResponderRelease={[Function]}
-                      onResponderTerminate={[Function]}
-                      onResponderTerminationRequest={[Function]}
-                      onStartShouldSetResponder={[Function]}
                       style={
                         Object {
-                          "alignItems": "center",
-                          "backgroundColor": "#fff",
-                          "borderBottomColor": "#e5e5e5",
-                          "borderBottomWidth": 1,
-                          "flexDirection": "row",
-                          "justifyContent": "space-between",
-                          "opacity": 1,
-                          "padding": 10,
-                          "paddingLeft": 30,
+                          "position": "absolute",
+                          "right": 30,
                         }
                       }
                     >
                       <View
                         style={
                           Object {
-                            "flexBasis": "75%",
+                            "alignItems": "center",
+                            "flexDirection": "row",
+                            "justifyContent": "space-between",
                           }
                         }
                       >
-                        <Text
-                          style={
-                            Object {
-                              "color": "#232b2b",
-                              "fontSize": 16,
-                              "fontWeight": "bold",
-                            }
-                          }
-                        >
-                          2
-                           - 
-                          Second Training
-                        </Text>
-                        <Text
-                          style={
-                            Object {
-                              "color": "#232b2b",
-                              "fontSize": 14,
-                            }
-                          }
-                        >
-                          This training session aims at..
-                        </Text>
-                      </View>
-                      <View
-                        style={
-                          Object {
-                            "position": "absolute",
-                            "right": 30,
-                          }
-                        }
-                      >
-                        <View
-                          style={
-                            Object {
-                              "alignItems": "center",
-                              "flexDirection": "row",
-                              "justifyContent": "space-between",
-                            }
-                          }
-                        >
-                          <Text />
-                        </View>
+                        <Text />
                       </View>
                     </View>
                   </View>
                 </View>
-              </RCTScrollView>
-            </View>
+                <View
+                  onLayout={[Function]}
+                  style={null}
+                >
+                  <View
+                    accessible={true}
+                    focusable={true}
+                    onClick={[Function]}
+                    onResponderGrant={[Function]}
+                    onResponderMove={[Function]}
+                    onResponderRelease={[Function]}
+                    onResponderTerminate={[Function]}
+                    onResponderTerminationRequest={[Function]}
+                    onStartShouldSetResponder={[Function]}
+                    style={
+                      Object {
+                        "alignItems": "center",
+                        "backgroundColor": "#fff",
+                        "borderBottomColor": "#e5e5e5",
+                        "borderBottomWidth": 1,
+                        "flexDirection": "row",
+                        "justifyContent": "space-between",
+                        "opacity": 1,
+                        "padding": 10,
+                        "paddingLeft": 30,
+                      }
+                    }
+                  >
+                    <View
+                      style={
+                        Object {
+                          "flexBasis": "75%",
+                        }
+                      }
+                    >
+                      <Text
+                        style={
+                          Object {
+                            "color": "#232b2b",
+                            "fontSize": 16,
+                            "fontWeight": "bold",
+                          }
+                        }
+                      >
+                        2
+                         - 
+                        Second Training
+                      </Text>
+                      <Text
+                        style={
+                          Object {
+                            "color": "#232b2b",
+                            "fontSize": 14,
+                          }
+                        }
+                      >
+                        This training session aims at..
+                      </Text>
+                    </View>
+                    <View
+                      style={
+                        Object {
+                          "position": "absolute",
+                          "right": 30,
+                        }
+                      }
+                    >
+                      <View
+                        style={
+                          Object {
+                            "alignItems": "center",
+                            "flexDirection": "row",
+                            "justifyContent": "space-between",
+                          }
+                        }
+                      >
+                        <Text />
+                      </View>
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </RCTScrollView>
           </View>
         </View>
       </View>
     </View>
-  </RCTScrollView>
-</View>
+  </View>
+</RCTScrollView>
 `;

--- a/src/Components/shared/ListItem.js
+++ b/src/Components/shared/ListItem.js
@@ -9,7 +9,7 @@ const ListItem = (props) => {
 
 const styles = StyleSheet.create({
   listItem: {
-    marginBottom: 10,
+    marginTop: 10,
     padding: 10,
     backgroundColor: theme.BACKGROUND_COLOR_LIGHT,
     shadowOffset: {

--- a/src/Components/shared/__snapshots__/ListItem.test.js.snap
+++ b/src/Components/shared/__snapshots__/ListItem.test.js.snap
@@ -6,7 +6,7 @@ exports[`<ListItem /> renders correctly 1`] = `
     Object {
       "backgroundColor": "#fff",
       "elevation": 3,
-      "marginBottom": 10,
+      "marginTop": 10,
       "padding": 10,
       "shadowOffset": Object {
         "height": 1,


### PR DESCRIPTION
Before sending your pull-request 💌 make sure :

- [x] The tests are up-to-date and your code is tested

### Drill page infos are equally spread on the screen

Before
(level was taking too much horizontal space)

![beforedrill](https://user-images.githubusercontent.com/3810795/99154338-3da09b00-26af-11eb-98c2-a5f4d9d32811.png)


After

![afterdriill](https://user-images.githubusercontent.com/3810795/99154340-41ccb880-26af-11eb-9ad7-1d1b5764702c.png)

### Program List top and bottom margin are cleaner

Before
(there was an ugly little margin at the top and bottom when scrolling)

![beforeprogram](https://user-images.githubusercontent.com/3810795/99154345-4e511100-26af-11eb-8185-d9b628444082.png)

After

![afterprogram](https://user-images.githubusercontent.com/3810795/99154348-55781f00-26af-11eb-8515-8941c300c71f.png)