### PR TITLE
Use a spinner instead of ugly text as a fallback

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import 'react-native-gesture-handler';
 import { PersistGate } from 'redux-persist/integration/react';
-import { Platform, Text } from 'react-native';
+import { Platform, ActivityIndicator } from 'react-native';
 import { NavigationContainer } from '@react-navigation/native';
 import { enableScreens } from 'react-native-screens';
 import { Provider as ReduxProvider } from 'react-redux';
@@ -12,6 +12,7 @@ import { Navigation } from './src/Navigation';
 import { store, persistor } from './src/Store/configureStore';
 import FlashMessage from './src/utils/flashMessage';
 import { EXPO_FIREBASE_URL_PREFIX } from '@env';
+import theme from './src/styles/theme.style';
 
 if (Platform.OS !== 'web') enableScreens();
 
@@ -31,7 +32,10 @@ const App = (props) => {
     <ReduxProvider store={store}>
       <PersistGate loading={null} persistor={persistor}>
         <PaperProvider>
-          <NavigationContainer linking={linking} fallback={<Text>Loading...</Text>}>
+          <NavigationContainer
+            linking={linking}
+            fallback={<ActivityIndicator animating color={theme.MAIN_COLOR} style={{ top: '45%' }} size="large" />}
+          >
             <Navigation />
           </NavigationContainer>
           <FlashMessage position="bottom" />


### PR DESCRIPTION
Before sending your pull-request 💌 make sure :

- [ ] The tests are up-to-date and your code is tested


When the app loads, there is a blank screen displayed shortly between the splash screen and the HomePage
This happens while the NavigationContainer is checking if there is a deep link to load the right screen.

I put a spinner instead of the ugly `Loading...` that was displayed at the top of the screen (behind the top bar)