### PR TITLE
Better rename modal

### DIFF
--- a/src/Components/__snapshots__/DictionaryPage.test.js.snap
+++ b/src/Components/__snapshots__/DictionaryPage.test.js.snap
@@ -179,7 +179,8 @@ exports[`<DictionaryPage /> renders correctly 1`] = `
         Object {
           "alignItems": "center",
           "flex": 1,
-          "justifyContent": "center",
+          "justifyContent": "flex-start",
+          "marginTop": "10%",
         }
       }
     >
@@ -192,6 +193,7 @@ exports[`<DictionaryPage /> renders correctly 1`] = `
             "elevation": 10,
             "maxHeight": "80%",
             "maxWidth": "80%",
+            "minWidth": "60%",
             "padding": 20,
             "shadowColor": "#000",
             "shadowOffset": Object {

--- a/src/Components/__snapshots__/PlayEditorPage.test.js.snap
+++ b/src/Components/__snapshots__/PlayEditorPage.test.js.snap
@@ -883,7 +883,8 @@ exports[`<PlayEditorPage /> renders correctly  with a currentPlay 1`] = `
             Object {
               "alignItems": "center",
               "flex": 1,
-              "justifyContent": "center",
+              "justifyContent": "flex-start",
+              "marginTop": "10%",
             }
           }
         >
@@ -896,6 +897,7 @@ exports[`<PlayEditorPage /> renders correctly  with a currentPlay 1`] = `
                 "elevation": 10,
                 "maxHeight": "80%",
                 "maxWidth": "80%",
+                "minWidth": "60%",
                 "padding": 20,
                 "shadowColor": "#000",
                 "shadowOffset": Object {
@@ -2002,7 +2004,8 @@ exports[`<PlayEditorPage /> renders correctly 1`] = `
             Object {
               "alignItems": "center",
               "flex": 1,
-              "justifyContent": "center",
+              "justifyContent": "flex-start",
+              "marginTop": "10%",
             }
           }
         >
@@ -2015,6 +2018,7 @@ exports[`<PlayEditorPage /> renders correctly 1`] = `
                 "elevation": 10,
                 "maxHeight": "80%",
                 "maxWidth": "80%",
+                "minWidth": "60%",
                 "padding": 20,
                 "shadowColor": "#000",
                 "shadowOffset": Object {

--- a/src/Components/editor/RenamePlayModal.test.js
+++ b/src/Components/editor/RenamePlayModal.test.js
@@ -43,7 +43,7 @@ describe('<RenamePlayModal />', () => {
     );
 
     // Fill input
-    fireEvent(getByPlaceholderText('Click here to enter the new name'), 'onChangeText', 'New Title');
+    fireEvent(getByPlaceholderText('Enter new name'), 'onChangeText', 'New Title');
 
     await act(async () => await fireEvent.press(getByText('Back')));
 
@@ -66,7 +66,7 @@ describe('<RenamePlayModal />', () => {
     );
 
     // Fill input
-    fireEvent(getByPlaceholderText('Click here to enter the new name'), 'onChangeText', 'New Title');
+    fireEvent(getByPlaceholderText('Enter new name'), 'onChangeText', 'New Title');
 
     await act(async () => await fireEvent.press(getByText('Apply')));
 

--- a/src/Components/editor/__snapshots__/RenamePlayModal.test.js.snap
+++ b/src/Components/editor/__snapshots__/RenamePlayModal.test.js.snap
@@ -37,7 +37,8 @@ exports[`<RenamePlayModal /> renders correctly 1`] = `
         Object {
           "alignItems": "center",
           "flex": 1,
-          "justifyContent": "center",
+          "justifyContent": "flex-start",
+          "marginTop": "10%",
         }
       }
     >
@@ -50,6 +51,7 @@ exports[`<RenamePlayModal /> renders correctly 1`] = `
             "elevation": 10,
             "maxHeight": "80%",
             "maxWidth": "80%",
+            "minWidth": "60%",
             "padding": 20,
             "shadowColor": "#000",
             "shadowOffset": Object {
@@ -93,7 +95,7 @@ exports[`<RenamePlayModal /> renders correctly 1`] = `
               <TextInput
                 allowFontScaling={true}
                 onChangeText={[Function]}
-                placeholder="Click here to enter the new name"
+                placeholder="Enter new name"
                 rejectResponderTermination={true}
                 style={
                   Object {

--- a/src/Components/editor/toolbar/__snapshots__/SavedPlaysList.test.js.snap
+++ b/src/Components/editor/toolbar/__snapshots__/SavedPlaysList.test.js.snap
@@ -74,7 +74,8 @@ exports[`<SavedPlaysList /> renders an empty state with no plays 1`] = `
         Object {
           "alignItems": "center",
           "flex": 1,
-          "justifyContent": "center",
+          "justifyContent": "flex-start",
+          "marginTop": "10%",
         }
       }
     >
@@ -87,6 +88,7 @@ exports[`<SavedPlaysList /> renders an empty state with no plays 1`] = `
             "elevation": 10,
             "maxHeight": "80%",
             "maxWidth": "80%",
+            "minWidth": "60%",
             "padding": 20,
             "shadowColor": "#000",
             "shadowOffset": Object {
@@ -267,7 +269,8 @@ exports[`<SavedPlaysList /> renders correctly with plays 1`] = `
         Object {
           "alignItems": "center",
           "flex": 1,
-          "justifyContent": "center",
+          "justifyContent": "flex-start",
+          "marginTop": "10%",
         }
       }
     >
@@ -280,6 +283,7 @@ exports[`<SavedPlaysList /> renders correctly with plays 1`] = `
             "elevation": 10,
             "maxHeight": "80%",
             "maxWidth": "80%",
+            "minWidth": "60%",
             "padding": 20,
             "shadowColor": "#000",
             "shadowOffset": Object {

--- a/src/Components/shared/Modal.js
+++ b/src/Components/shared/Modal.js
@@ -30,12 +30,14 @@ const styles = StyleSheet.create({
   },
   centeredView: {
     flex: 1,
-    justifyContent: 'center',
+    marginTop: '10%',
+    justifyContent: 'flex-start',
     alignItems: 'center',
   },
   modalView: {
     maxHeight: '80%',
     maxWidth: '80%',
+    minWidth: '60%',
     backgroundColor: 'white',
     borderRadius: 10,
     padding: 20,

--- a/src/Components/shared/__snapshots__/Modal.test.js.snap
+++ b/src/Components/shared/__snapshots__/Modal.test.js.snap
@@ -36,7 +36,8 @@ exports[`<Modal /> renders correctly 1`] = `
       Object {
         "alignItems": "center",
         "flex": 1,
-        "justifyContent": "center",
+        "justifyContent": "flex-start",
+        "marginTop": "10%",
       }
     }
   >
@@ -49,6 +50,7 @@ exports[`<Modal /> renders correctly 1`] = `
           "elevation": 10,
           "maxHeight": "80%",
           "maxWidth": "80%",
+          "minWidth": "60%",
           "padding": 20,
           "shadowColor": "#000",
           "shadowOffset": Object {

--- a/src/utils/locales/en.js
+++ b/src/utils/locales/en.js
@@ -126,7 +126,7 @@ export default {
       deleteSuccess: "The play '{{title}}' has been deleted.",
     },
     renamePlayModal: {
-      placeholder: 'Click here to enter the new name',
+      placeholder: 'Enter new name',
       alreadyExists: 'This name already exists',
       empty: 'You cannot set an empty name',
       renameSuccess: 'The play was successfully renamed!',

--- a/src/utils/locales/fr.js
+++ b/src/utils/locales/fr.js
@@ -126,7 +126,7 @@ export default {
       deleteSuccess: 'Le play "{{title}}" a été supprimé.',
     },
     renamePlayModal: {
-      placeholder: 'Appuyer ici pour renommer',
+      placeholder: 'Entrez un nom',
       alreadyExists: 'Ce nom existe déjà',
       empty: 'Le nom ne peut pas être vide',
       renameSuccess: 'Le play a été renommée avec succès',


### PR DESCRIPTION
Before sending your pull-request 💌 make sure :

- [x] The tests are up-to-date and your code is tested

On ios, the modal to rename a play is hidden (especially the back button) behind the keyboard

Also the placeholder text was too long