### PR TITLE
Smaller titles in drill list

### DIFF
--- a/src/Components/__snapshots__/DrillListPage.test.js.snap
+++ b/src/Components/__snapshots__/DrillListPage.test.js.snap
@@ -863,7 +863,7 @@ exports[`<DrillListPage /> renders correctly when connected 1`] = `
                 Object {
                   "flex": 3,
                   "flexWrap": "wrap",
-                  "fontSize": 20,
+                  "fontSize": 16,
                   "fontWeight": "bold",
                 }
               }
@@ -998,7 +998,7 @@ exports[`<DrillListPage /> renders correctly when connected 1`] = `
                 Object {
                   "flex": 3,
                   "flexWrap": "wrap",
-                  "fontSize": 20,
+                  "fontSize": 16,
                   "fontWeight": "bold",
                 }
               }
@@ -1472,7 +1472,7 @@ exports[`<DrillListPage /> renders fitness drills sorted by duration 1`] = `
                 Object {
                   "flex": 3,
                   "flexWrap": "wrap",
-                  "fontSize": 20,
+                  "fontSize": 16,
                   "fontWeight": "bold",
                 }
               }
@@ -1607,7 +1607,7 @@ exports[`<DrillListPage /> renders fitness drills sorted by duration 1`] = `
                 Object {
                   "flex": 3,
                   "flexWrap": "wrap",
-                  "fontSize": 20,
+                  "fontSize": 16,
                   "fontWeight": "bold",
                 }
               }
@@ -1742,7 +1742,7 @@ exports[`<DrillListPage /> renders fitness drills sorted by duration 1`] = `
                 Object {
                   "flex": 3,
                   "flexWrap": "wrap",
-                  "fontSize": 20,
+                  "fontSize": 16,
                   "fontWeight": "bold",
                 }
               }
@@ -2216,7 +2216,7 @@ exports[`<DrillListPage /> renders frisbee drills sorted by number of players 1`
                 Object {
                   "flex": 3,
                   "flexWrap": "wrap",
-                  "fontSize": 20,
+                  "fontSize": 16,
                   "fontWeight": "bold",
                 }
               }
@@ -2351,7 +2351,7 @@ exports[`<DrillListPage /> renders frisbee drills sorted by number of players 1`
                 Object {
                   "flex": 3,
                   "flexWrap": "wrap",
-                  "fontSize": 20,
+                  "fontSize": 16,
                   "fontWeight": "bold",
                 }
               }
@@ -2486,7 +2486,7 @@ exports[`<DrillListPage /> renders frisbee drills sorted by number of players 1`
                 Object {
                   "flex": 3,
                   "flexWrap": "wrap",
-                  "fontSize": 20,
+                  "fontSize": 16,
                   "fontWeight": "bold",
                 }
               }

--- a/src/Components/__snapshots__/TrainingPage.test.js.snap
+++ b/src/Components/__snapshots__/TrainingPage.test.js.snap
@@ -1051,7 +1051,7 @@ exports[`<TrainingPage /> When fitness program renders correctly a fitness train
                   Object {
                     "flex": 3,
                     "flexWrap": "wrap",
-                    "fontSize": 20,
+                    "fontSize": 16,
                     "fontWeight": "bold",
                   }
                 }
@@ -1187,7 +1187,7 @@ exports[`<TrainingPage /> When fitness program renders correctly a fitness train
                   Object {
                     "flex": 3,
                     "flexWrap": "wrap",
-                    "fontSize": 20,
+                    "fontSize": 16,
                     "fontWeight": "bold",
                   }
                 }
@@ -2236,7 +2236,7 @@ exports[`<TrainingPage /> When fitness program renders correctly a fitness train
                   Object {
                     "flex": 3,
                     "flexWrap": "wrap",
-                    "fontSize": 20,
+                    "fontSize": 16,
                     "fontWeight": "bold",
                   }
                 }
@@ -2372,7 +2372,7 @@ exports[`<TrainingPage /> When fitness program renders correctly a fitness train
                   Object {
                     "flex": 3,
                     "flexWrap": "wrap",
-                    "fontSize": 20,
+                    "fontSize": 16,
                     "fontWeight": "bold",
                   }
                 }
@@ -3642,7 +3642,7 @@ exports[`<TrainingPage /> When frisbee program renders correctly a frisbee train
                   Object {
                     "flex": 3,
                     "flexWrap": "wrap",
-                    "fontSize": 20,
+                    "fontSize": 16,
                     "fontWeight": "bold",
                   }
                 }
@@ -3778,7 +3778,7 @@ exports[`<TrainingPage /> When frisbee program renders correctly a frisbee train
                   Object {
                     "flex": 3,
                     "flexWrap": "wrap",
-                    "fontSize": 20,
+                    "fontSize": 16,
                     "fontWeight": "bold",
                   }
                 }
@@ -5034,7 +5034,7 @@ exports[`<TrainingPage /> When frisbee program renders correctly a frisbee train
                   Object {
                     "flex": 3,
                     "flexWrap": "wrap",
-                    "fontSize": 20,
+                    "fontSize": 16,
                     "fontWeight": "bold",
                   }
                 }
@@ -5170,7 +5170,7 @@ exports[`<TrainingPage /> When frisbee program renders correctly a frisbee train
                   Object {
                     "flex": 3,
                     "flexWrap": "wrap",
-                    "fontSize": 20,
+                    "fontSize": 16,
                     "fontWeight": "bold",
                   }
                 }

--- a/src/Components/shared/__snapshots__/DrillList.test.js.snap
+++ b/src/Components/shared/__snapshots__/DrillList.test.js.snap
@@ -214,7 +214,7 @@ exports[`<DrillList /> renders correctly 1`] = `
               Object {
                 "flex": 3,
                 "flexWrap": "wrap",
-                "fontSize": 20,
+                "fontSize": 16,
                 "fontWeight": "bold",
               }
             }

--- a/src/styles/list.style.js
+++ b/src/styles/list.style.js
@@ -40,7 +40,7 @@ export const itemContentContainer = {
 export const title = {
   flex: 3,
   fontWeight: 'bold',
-  fontSize: theme.FONT_SIZE_LARGE,
+  fontSize: theme.FONT_SIZE_MEDIUM,
   flexWrap: 'wrap',
 };
 export const source = {


### PR DESCRIPTION
Before sending your pull-request 💌 make sure :

- [x] The tests are up-to-date and your code is tested

C'est un test, je veux bien ton avis dessus ?
J'ai fait ça parce qu'il y a plein de drills dont le titre ne s'affiche pas en entier sur l'iphone car trop gros (genre on voit 1 tier du titre)

T'en penses quoi ?